### PR TITLE
fix(intake): detach gRPC Context for engine.intakeHandoff calls

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle properties
 
 # Managed via `ai.pipestream:pipestream-bom` (see build.gradle)
-pipestreamBomVersion=0.7.24-SNAPSHOT
+pipestreamBomVersion=0.7.25-SNAPSHOT
 
 # Increase Gradle Daemon memory to prevent GC thrashing during build/compilation
 org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g

--- a/src/main/java/ai/pipeline/connector/intake/service/EngineClient.java
+++ b/src/main/java/ai/pipeline/connector/intake/service/EngineClient.java
@@ -10,10 +10,13 @@ import ai.pipestream.engine.v1.MutinyEngineV1ServiceGrpc;
 import ai.pipestream.quarkus.dynamicgrpc.DynamicGrpcClientFactory;
 import ai.pipestream.server.constants.PipestreamServices;
 import com.google.protobuf.Timestamp;
+import io.grpc.Context;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
+
+import java.util.function.Supplier;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -107,8 +110,9 @@ public class EngineClient {
             .setAccountId(accountId)
             .build();
 
-        return grpcClientFactory.getClient(ENGINE_SERVICE_NAME, MutinyEngineV1ServiceGrpc::newMutinyStub)
-            .flatMap(stub -> stub.intakeHandoff(request))
+        return underRootContext(() ->
+                grpcClientFactory.getClient(ENGINE_SERVICE_NAME, MutinyEngineV1ServiceGrpc::newMutinyStub)
+                        .flatMap(stub -> stub.intakeHandoff(request)))
             .invoke(response -> {
                 if (response.getAccepted()) {
                     LOG.debugf("Engine accepted document: doc_id=%s, stream_id=%s, entry_node=%s",
@@ -195,8 +199,9 @@ public class EngineClient {
             .setAccountId(accountId)
             .build();
 
-        return grpcClientFactory.getClient(ENGINE_SERVICE_NAME, MutinyEngineV1ServiceGrpc::newMutinyStub)
-            .flatMap(stub -> stub.intakeHandoff(request))
+        return underRootContext(() ->
+                grpcClientFactory.getClient(ENGINE_SERVICE_NAME, MutinyEngineV1ServiceGrpc::newMutinyStub)
+                        .flatMap(stub -> stub.intakeHandoff(request)))
             .invoke(response -> {
                 if (response.getAccepted()) {
                     LOG.debugf("Engine accepted document ref: doc_id=%s, stream_id=%s, entry_node=%s",
@@ -206,5 +211,33 @@ public class EngineClient {
                         docId, response.getMessage());
                 }
             });
+    }
+
+    /**
+     * Subscribes to {@code supplier}'s Uni under {@link Context#ROOT} so the
+     * outbound gRPC client call captures ROOT as its parent Context instead of
+     * the inbound RPC handler's Context.
+     * <p>
+     * Without this, every {@code uploadPipeDoc} that fans out to
+     * {@code engine.intakeHandoff} carries the inbound UploadPipeDoc handler's
+     * Context as the parent of the outbound call. As soon as the upstream
+     * Mutiny chain emits the response and the inbound handler's Context cancels
+     * — under load this happens with calls still in flight — every outbound
+     * call rooted at it dies with
+     * {@code CANCELLED: io.grpc.Context was cancelled without error}.
+     * Observed under JDBC transport-test crawls: 75 of 100 docs cancelled
+     * within a single 230 ms window once the engine channel finished
+     * resolving. ROOT never cancels, so the outbound call survives whatever
+     * the inbound handler's Context does next.
+     */
+    private static <T> Uni<T> underRootContext(Supplier<Uni<T>> supplier) {
+        return Uni.createFrom().<T>emitter(emitter -> {
+            Context previous = Context.ROOT.attach();
+            try {
+                supplier.get().subscribe().with(emitter::complete, emitter::fail);
+            } finally {
+                Context.ROOT.detach(previous);
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary

- Wraps the Mutiny subscription in `EngineClient.handoffToEngine` / `handoffReferenceToEngine` under `Context.ROOT` so the outbound `engine.intakeHandoff` call captures ROOT (which never cancels) instead of the inbound `uploadPipeDoc` handler's Context. Same shape as the engine-side fix in [pipestream-engine#engine-refactor/pr0 f815d2a](https://github.com/ai-pipestream/pipestream-engine/commit/f815d2a).
- Bumps `pipestreamBomVersion` to `0.7.25-SNAPSHOT` to pick up the platform's dynamic-grpc Netty migration (`#75`/`#76`/`#73`).

## Why

Under a JDBC transport-test crawl, 75 of 100 docs were dropped at the engine handoff with `CANCELLED: io.grpc.Context was cancelled without error`. Root cause: gRPC client captures `Context.current()` at subscription time and registers a cancellation listener. Once the inbound `uploadPipeDoc` handler emits its response and its Context cancels, every still-in-flight outbound `engine.intakeHandoff` call rooted at that Context dies — symptom is a wave of CANCELLEDs in a single ~230 ms window once the engine channel finishes resolving.

The connector-intake error path then forwards `throwable.getMessage()` back to the JDBC connector as `UploadPipeDocResponse(success=false, message=\"CANCELLED: ...\")`, which is how the message surfaces in jdbc-connector logs without the usual `\"Engine rejected:\"` prefix.

## Test plan

- [x] `./gradlew test` — 32/32 pass
- [x] End-to-end via process-compose: `transport-e2e-03b8d218` JDBC crawl moves 1000/1000 rows in 2.8 s with zero CANCELLED in either service log; `engine.doc.success` climbs from 0 to 3101 across the run with `engine.doc.failure` pinned at 0.

## Notes

This is the band-aid fix that unblocks crawls today. The architectural fix (server fast-ack + per-service worker queue, dropping fire-and-forget from inside RPC handlers entirely) is planned as a separate PR.